### PR TITLE
Doc view: Changed download button's radius for better look

### DIFF
--- a/view-doc.js
+++ b/view-doc.js
@@ -31,8 +31,9 @@ function generatePDF() {
 function createDownloadButton() {
     let downloadBtn = document.createElement("button");
     downloadBtn.classList.add("download-button-1");
-    downloadBtn.style.borderRadius = '9999px';
-    downloadBtn.innerHTML = '<svg aria-hidden="true" focusable="false" data-prefix="fas" class="svg-inline--fa" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512"><path fill="currentColor" d="M432 288h-80v-192h-64v192h-80l112 128 112-128zM0 400v48c0 35.346 28.654 64 64 64h512c35.346 0 64-28.654 64-64v-48h-640z"></path></svg><span class="download-text">Download</span>';
+    downloadBtn.style.borderRadius = '20px'
+    downloadBtn.style.margin = 'auto';
+    downloadBtn.innerHTML = '<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="cloud-arrow-down" class="svg-inline--fa fa-cloud-arrow-down fa-fw _db78be352894 _6d88284663af" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512"><path fill="currentColor" d="M144 480C64.5 480 0 415.5 0 336c0-62.8 40.2-116.2 96.2-135.9c-.1-2.7-.2-5.4-.2-8.1c0-88.4 71.6-160 160-160c59.3 0 111 32.2 138.7 80.2C409.9 102 428.3 96 448 96c53 0 96 43 96 96c0 12.2-2.3 23.8-6.4 34.6C596 238.4 640 290.1 640 352c0 70.7-57.3 128-128 128H144zm79-167l80 80c9.4 9.4 24.6 9.4 33.9 0l80-80c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-39 39V184c0-13.3-10.7-24-24-24s-24 10.7-24 24V318.1l-39-39c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9z"></path></svg><span class="download-text">Download</span>';
     downloadBtn.addEventListener('click', (event) => {
         event.preventDefault();
         event.stopPropagation();

--- a/view-doc.js
+++ b/view-doc.js
@@ -31,6 +31,7 @@ function generatePDF() {
 function createDownloadButton() {
     let downloadBtn = document.createElement("button");
     downloadBtn.classList.add("download-button-1");
+    downloadBtn.style.borderRadius = '9999px';
     downloadBtn.innerHTML = '<svg aria-hidden="true" focusable="false" data-prefix="fas" class="svg-inline--fa" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512"><path fill="currentColor" d="M432 288h-80v-192h-64v192h-80l112 128 112-128zM0 400v48c0 35.346 28.654 64 64 64h512c35.346 0 64-28.654 64-64v-48h-640z"></path></svg><span class="download-text">Download</span>';
     downloadBtn.addEventListener('click', (event) => {
         event.preventDefault();

--- a/view-doc.js
+++ b/view-doc.js
@@ -32,7 +32,6 @@ function createDownloadButton() {
     let downloadBtn = document.createElement("button");
     downloadBtn.classList.add("download-button-1");
     downloadBtn.style.borderRadius = '20px'
-    downloadBtn.style.margin = 'auto';
     downloadBtn.innerHTML = '<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="cloud-arrow-down" class="svg-inline--fa fa-cloud-arrow-down fa-fw _db78be352894 _6d88284663af" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512"><path fill="currentColor" d="M144 480C64.5 480 0 415.5 0 336c0-62.8 40.2-116.2 96.2-135.9c-.1-2.7-.2-5.4-.2-8.1c0-88.4 71.6-160 160-160c59.3 0 111 32.2 138.7 80.2C409.9 102 428.3 96 448 96c53 0 96 43 96 96c0 12.2-2.3 23.8-6.4 34.6C596 238.4 640 290.1 640 352c0 70.7-57.3 128-128 128H144zm79-167l80 80c9.4 9.4 24.6 9.4 33.9 0l80-80c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-39 39V184c0-13.3-10.7-24-24-24s-24 10.7-24 24V318.1l-39-39c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9z"></path></svg><span class="download-text">Download</span>';
     downloadBtn.addEventListener('click', (event) => {
         event.preventDefault();


### PR DESCRIPTION
just an extra...  changed the border radius of the download button and replaced the icon with the icon that they use for download

before:
![image](https://github.com/user-attachments/assets/6b33b7cd-a3c2-4e6b-b3cd-b7547c8b11f3)

after:
![image](https://github.com/user-attachments/assets/5aa49a63-dfa0-4811-9a7b-24fd109d0712)
> ignore the locale change, i tested it with studersnel

Implementation's not that great, but hey, I think the look is now better :D.